### PR TITLE
Draft of changes for dining commons

### DIFF
--- a/frontend/src/fixtures/diningCommonsFixtures.js
+++ b/frontend/src/fixtures/diningCommonsFixtures.js
@@ -1,0 +1,43 @@
+const diningCommonsFixtures = {
+    oneDiningCommons: {
+        "name": "Carrillo",
+        "code": "carrillo",
+        "hasSackMeal": false,
+        "hasTakeOutMeal": false,
+        "hasDiningCam": true,
+        "latitude": 34.409953,
+        "longitude": -119.85277
+    },
+    threeCommons: [
+        {
+            "name": "De La Guerra",
+            "code": "de-la-guerra",
+            "hasSackMeal": false,
+            "hasTakeOutMeal": false,
+            "hasDiningCam": true,
+            "latitude": 34.409811,
+            "longitude": -119.845026
+        },
+        {
+            "name": "Ortega",
+            "code": "ortega",
+            "hasSackMeal": true,
+            "hasTakeOutMeal": true,
+            "hasDiningCam": true,
+            "latitude": 34.410987,
+            "longitude": -119.84709
+        },
+        {
+            "name": "Portola",
+            "code": "portola",
+            "hasSackMeal": true,
+            "hasTakeOutMeal": true,
+            "hasDiningCam": true,
+            "latitude": 34.417723,
+            "longitude": -119.867427
+        } 
+    ]
+};
+
+
+export { diningCommonsFixtures };

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -1,0 +1,76 @@
+import OurTable from "main/components/OurTable";
+// import { useBackendMutation } from "main/utils/useBackend";
+// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+// import { useNavigate } from "react-router-dom";
+// import { hasRole } from "main/utils/currentUser";
+
+export default function DiningCommonsTable({ diningCommons, _currentUser }) {
+
+    // const navigate = useNavigate();
+
+    // const editCallback = (cell) => {
+    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
+    // }
+
+    // Stryker disable all : hard to test for query caching
+    // const deleteMutation = useBackendMutation(
+    //     cellToAxiosParamsDelete,
+    //     { onSuccess: onDeleteSuccess },
+    //     ["/api/ucsbdates/all"]
+    // );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'Code',
+            accessor: 'code', 
+        },
+        {
+            Header: 'Name',
+            accessor: 'name',
+        },
+        {
+            Header: 'Sack Meal?',
+            accessor: 'hasSackMeal',
+            accessor: (row, _rowIndex) => String(row.hasSackMeal) // hack needed for boolean values to show up
+        },
+        {
+            Header: 'Takeout Meal?',
+            accessor: 'hasTakeOutMeal',
+            accessor: (row, _rowIndex) => String(row.hasTakeOutMeal) // hack needed for boolean values to show up
+
+        },
+        {
+            Header: 'Dining Cam?',
+            accessor: 'hasDiningCam',
+            accessor: (row, _rowIndex) => String(row.hasDiningCam) // hack needed for boolean values to show up
+        },
+        {
+            Header: 'Latitude',
+            accessor: 'latitude',
+        },
+        {
+            Header: 'Longitude',
+            accessor: 'longitude',
+        }
+    ];
+
+    // const columnsIfAdmin = [
+    //     ...columns,
+    //     ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+    //     ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
+    // ];
+
+    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    const columnsToDisplay = columns;
+
+    return <OurTable
+        data={diningCommons}
+        columns={columnsToDisplay}
+        testid={"DiningCommonsTable"}
+    />;
+};

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -1,10 +1,21 @@
-import OurTable from "main/components/OurTable";
-// import { useBackendMutation } from "main/utils/useBackend";
-// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import OurTable, { ButtonColumn} from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import {  onDeleteSuccess } from "main/utils/UCSBDateUtils"
 // import { useNavigate } from "react-router-dom";
-// import { hasRole } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 
-export default function DiningCommonsTable({ diningCommons, _currentUser }) {
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/ucsbdiningcommons",
+        method: "DELETE",
+        params: {
+            code: cell.row.values.code
+        }
+    }
+}
+
+export default function DiningCommonsTable({ diningCommons, currentUser }) {
 
     // const navigate = useNavigate();
 
@@ -13,15 +24,15 @@ export default function DiningCommonsTable({ diningCommons, _currentUser }) {
     // }
 
     // Stryker disable all : hard to test for query caching
-    // const deleteMutation = useBackendMutation(
-    //     cellToAxiosParamsDelete,
-    //     { onSuccess: onDeleteSuccess },
-    //     ["/api/ucsbdates/all"]
-    // );
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/ucsbdiningcommons/all"]
+    );
     // Stryker enable all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
-    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
     const columns = [
         {
@@ -58,15 +69,13 @@ export default function DiningCommonsTable({ diningCommons, _currentUser }) {
         }
     ];
 
-    // const columnsIfAdmin = [
-    //     ...columns,
-    //     ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
-    //     ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
-    // ];
+    const columnsIfAdmin = [
+        ...columns,
+        // ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable", "code")
+    ];
 
-    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
-
-    const columnsToDisplay = columns;
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={diningCommons}

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -46,17 +46,20 @@ export default function DiningCommonsTable({ diningCommons, currentUser }) {
         {
             Header: 'Sack Meal?',
             accessor: 'hasSackMeal',
+            id: 'hasSackMeal', // needed for tests
             accessor: (row, _rowIndex) => String(row.hasSackMeal) // hack needed for boolean values to show up
         },
         {
             Header: 'Takeout Meal?',
             accessor: 'hasTakeOutMeal',
+            id: 'hasTakeOutMeal', // needed for tests
             accessor: (row, _rowIndex) => String(row.hasTakeOutMeal) // hack needed for boolean values to show up
 
         },
         {
             Header: 'Dining Cam?',
             accessor: 'hasDiningCam',
+            id: 'hasDiningCam', // needed for tests
             accessor: (row, _rowIndex) => String(row.hasDiningCam) // hack needed for boolean values to show up
         },
         {
@@ -69,10 +72,12 @@ export default function DiningCommonsTable({ diningCommons, currentUser }) {
         }
     ];
 
+    const testid = "DiningCommonsTable";
+
     const columnsIfAdmin = [
         ...columns,
-        // ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
-        ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable", "code")
+        // ButtonColumn("Edit", "primary", editCallback, testid),
+        ButtonColumn("Delete", "danger", deleteCallback, testid)
     ];
 
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
@@ -80,6 +85,6 @@ export default function DiningCommonsTable({ diningCommons, currentUser }) {
     return <OurTable
         data={diningCommons}
         columns={columnsToDisplay}
-        testid={"DiningCommonsTable"}
+        testid={testid}
     />;
 };

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -45,20 +45,17 @@ export default function DiningCommonsTable({ diningCommons, currentUser }) {
         },
         {
             Header: 'Sack Meal?',
-            accessor: 'hasSackMeal',
             id: 'hasSackMeal', // needed for tests
             accessor: (row, _rowIndex) => String(row.hasSackMeal) // hack needed for boolean values to show up
         },
         {
             Header: 'Takeout Meal?',
-            accessor: 'hasTakeOutMeal',
             id: 'hasTakeOutMeal', // needed for tests
             accessor: (row, _rowIndex) => String(row.hasTakeOutMeal) // hack needed for boolean values to show up
 
         },
         {
             Header: 'Dining Cam?',
-            accessor: 'hasDiningCam',
             id: 'hasDiningCam', // needed for tests
             accessor: (row, _rowIndex) => String(row.hasDiningCam) // hack needed for boolean values to show up
         },

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -83,7 +83,7 @@ export default function OurTable({ columns, data, testid = "testid" }) {
 //   ButtonColumn("Delete", "danger", deleteCallback)
 // ];
 
-export function ButtonColumn(label, variant, callback, testid) {
+export function ButtonColumn(label, variant, callback, testid, idfield="id") {
   const column = {
     Header: label,
     id: label,
@@ -91,7 +91,7 @@ export function ButtonColumn(label, variant, callback, testid) {
       <Button
         variant={variant}
         onClick={() => callback(cell)}
-        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column[idfield]}-button`}
       >
         {label}
       </Button>

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -46,7 +46,7 @@ export default function OurTable({ columns, data, testid = "testid" }) {
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                   >
-                    {cell.render('Cell')}
+                    {cell.render('Cell') } 
                   </td>
                 )
               })}
@@ -83,7 +83,7 @@ export default function OurTable({ columns, data, testid = "testid" }) {
 //   ButtonColumn("Delete", "danger", deleteCallback)
 // ];
 
-export function ButtonColumn(label, variant, callback, testid, idfield="id") {
+export function ButtonColumn(label, variant, callback, testid) {
   const column = {
     Header: label,
     id: label,
@@ -91,7 +91,7 @@ export function ButtonColumn(label, variant, callback, testid, idfield="id") {
       <Button
         variant={variant}
         onClick={() => callback(cell)}
-        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column[idfield]}-button`}
+        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
       >
         {label}
       </Button>

--- a/frontend/src/main/pages/DiningCommons/DiningCommonsIndexPage.js
+++ b/frontend/src/main/pages/DiningCommons/DiningCommonsIndexPage.js
@@ -1,13 +1,28 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import DiningCommonsTable from 'main/components/DiningCommons/DiningCommonsTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function DiningCommonsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: diningCommons, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/ucsbdiningcommons/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/ucsbdiningcommons/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Dining Commons</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <h1>UCSB Dining Commons</h1>
+        <DiningCommonsTable diningCommons={diningCommons} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesIndexPage.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { useBackend } from 'main/utils/useBackend';
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UCSBDatesTable from 'main/components/UCSBDates/UCSBDatesTable';
-import { useCurrentUser } from 'main/utils/currentUser'
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function UCSBDatesIndexPage() {
 

--- a/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
+import { diningCommonsFixtures } from 'fixtures/diningCommonsFixtures';
+
+export default {
+    title: 'components/DiningCommons/DiningCommonsTable',
+    component: DiningCommonsTable
+};
+
+const Template = (args) => {
+    return (
+        <DiningCommonsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    diningCommons: []
+};
+
+export const ThreeDates = Template.bind({});
+
+ThreeDates.args = {
+    diningCommons: diningCommonsFixtures.threeCommons
+};
+
+

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -1,0 +1,126 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
+import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("DiningCommonsTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DiningCommonsTable diningCommons={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DiningCommonsTable diningCommons={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DiningCommonsTable diningCommons={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DiningCommonsTable diningCommons={diningCommonsFixtures.threeCommons} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    const expectedHeaders = ['Code',  'Name', 'Sack Meal?','Takeout Meal?','Dining Cam?','Latitude','Longitude'];
+    const expectedFields = ['code', 'name','hasSackMeal', 'hasTakeOutMeal','hasDiningCam','latitude','longitude'];
+    const testId = "DiningCommonsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra");
+    expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
+    expect(getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("De La Guerra");
+    expect(getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("Ortega");
+    
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  // test("Edit button navigates to the edit page for admin user", async () => {
+
+  //   const currentUser = currentUserFixtures.adminUser;
+
+  //   const { getByTestId } = render(
+  //     <QueryClientProvider client={queryClient}>
+  //       <MemoryRouter>
+  //         <UCSBDatesTable diningCommons={ucsbDatesFixtures.threeDates} currentUser={currentUser} />
+  //       </MemoryRouter>
+  //     </QueryClientProvider>
+
+  //   );
+
+  //   await waitFor(() => { expect(getByTestId(`UCSBDatesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+  //   const editButton = getByTestId(`UCSBDatesTable-cell-row-0-col-Edit-button`);
+  //   expect(editButton).toBeInTheDocument();
+    
+  //   fireEvent.click(editButton);
+
+  //   await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdates/edit/1'));
+
+  // });
+
+});
+

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import {  render } from "@testing-library/react";
 import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
 import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
 import { QueryClient, QueryClientProvider } from "react-query";

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -87,7 +87,7 @@ describe("DiningCommonsTable tests", () => {
     expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
     expect(getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("De La Guerra");
     expect(getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("Ortega");
-    
+
     // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     // expect(editButton).toBeInTheDocument();
     // expect(editButton).toHaveClass("btn-primary");
@@ -121,6 +121,7 @@ describe("DiningCommonsTable tests", () => {
   //   await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdates/edit/1'));
 
   // });
+
 
 });
 

--- a/frontend/src/tests/components/UCSBDates/UCSBDatesTable.test.js
+++ b/frontend/src/tests/components/UCSBDates/UCSBDatesTable.test.js
@@ -13,7 +13,7 @@ jest.mock('react-router-dom', () => ({
     useNavigate: () => mockedNavigate
 }));
 
-describe("UserTable tests", () => {
+describe("UCSBDatesTable tests", () => {
   const queryClient = new QueryClient();
 
 

--- a/frontend/src/tests/pages/DiningCommons/DiningCommonsIndexPage.test.js
+++ b/frontend/src/tests/pages/DiningCommons/DiningCommonsIndexPage.test.js
@@ -143,7 +143,7 @@ describe("UCSBDatesIndexPage tests", () => {
 
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
-        axiosMock.onDelete("/api/ucsbdiningcommons").reply(200, "DiningCommons with id de-la-guerra was deleted");
+        axiosMock.onDelete("/api/ucsbdiningcommons", {params: {code: "de-la-guerra"}}).reply(200, "DiningCommons with id de-la-guerra was deleted");
 
 
         const { getByTestId } = render(

--- a/frontend/src/tests/pages/DiningCommons/DiningCommonsIndexPage.test.js
+++ b/frontend/src/tests/pages/DiningCommons/DiningCommonsIndexPage.test.js
@@ -1,4 +1,4 @@
-import { _fireEvent, render, _waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import DiningCommonsIndexPage from "main/pages/DiningCommons/DiningCommonsIndexPage";
@@ -6,7 +6,7 @@ import DiningCommonsIndexPage from "main/pages/DiningCommons/DiningCommonsIndexP
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-// import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
+import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import _mockConsole from "jest-mock-console";
@@ -26,7 +26,7 @@ describe("UCSBDatesIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
 
-    const _testId = "DiningCommonsTable";
+    const testId = "DiningCommonsTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -74,99 +74,99 @@ describe("UCSBDatesIndexPage tests", () => {
 
     });
 
-    // test("renders three diningCommon without crashing for regular user", async () => {
-    //     setupUserOnly();
-    //     const queryClient = new QueryClient();
-    //     axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
+    test("renders three diningCommon without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
 
-    //     const { getByTestId } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <DiningCommonsIndexPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DiningCommonsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
 
-    //     await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); } );
-    //     expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
-    //     expect(getByTestId(`${testId}-cell-row-2-col-code`)).toHaveTextContent("portola");
+        await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); } );
+        expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
+        expect(getByTestId(`${testId}-cell-row-2-col-code`)).toHaveTextContent("portola");
 
-    // });
+    });
 
-    // test("renders three diningCommons without crashing for admin user", async () => {
-    //     setupAdminUser();
-    //     const queryClient = new QueryClient();
-    //     axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
+    test("renders three diningCommons without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
 
-    //     const { getByTestId } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <DiningCommonsIndexPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DiningCommonsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
 
-    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); });
-    //     expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
-    //     expect(getByTestId(`${testId}-cell-row-2-col-code`)).toHaveTextContent("portola");
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
+        expect(getByTestId(`${testId}-cell-row-2-col-code`)).toHaveTextContent("portola");
 
-    // });
+    });
 
-    // test("renders empty table when backend unavailable, user only", async () => {
-    //     setupUserOnly();
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
 
-    //     const queryClient = new QueryClient();
-    //     axiosMock.onGet("/api/ucsbdiningcommons/all").timeout();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbdiningcommons/all").timeout();
 
-    //     const { queryByTestId, getByText } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <DiningCommonsIndexPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
+        const { queryByTestId, getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DiningCommonsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
 
-    //     await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3); });
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3); });
 
-    //     const expectedHeaders = ['Code',  'Name', 'Sack Meal?','Takeout Meal?','Dining Cam?','Latitude','Longitude'];
+        const expectedHeaders = ['Code',  'Name', 'Sack Meal?','Takeout Meal?','Dining Cam?','Latitude','Longitude'];
     
-    //     expectedHeaders.forEach((headerText) => {
-    //       const header = getByText(headerText);
-    //       expect(header).toBeInTheDocument();
-    //     });
+        expectedHeaders.forEach((headerText) => {
+          const header = getByText(headerText);
+          expect(header).toBeInTheDocument();
+        });
 
-    //     expect(queryByTestId(`${testId}-cell-row-0-col-code`)).not.toBeInTheDocument();
-    // });
+        expect(queryByTestId(`${testId}-cell-row-0-col-code`)).not.toBeInTheDocument();
+    });
 
-    // test("test what happens when you click delete, admin", async () => {
-    //     setupAdminUser();
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
 
-    //     const queryClient = new QueryClient();
-    //     axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
-    //     axiosMock.onDelete("/api/ucsbdiningcommons", {params: {code: "de-la-guerra"}}).reply(200, "DiningCommons with id de-la-guerra was deleted");
-
-
-    //     const { getByTestId } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <DiningCommonsIndexPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
-
-    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toBeInTheDocument(); });
-
-    //    expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); 
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
+        axiosMock.onDelete("/api/ucsbdiningcommons").reply(200, "DiningCommons with id de-la-guerra was deleted");
 
 
-    //     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    //     expect(deleteButton).toBeInTheDocument();
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DiningCommonsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toBeInTheDocument(); });
+
+       expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); 
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
        
-    //     fireEvent.click(deleteButton);
+        fireEvent.click(deleteButton);
 
-    //     await waitFor(() => { expect(mockToast).toBeCalledWith("DiningCommons with id de-la-guerra was deleted") });
+        await waitFor(() => { expect(mockToast).toBeCalledWith("DiningCommons with id de-la-guerra was deleted") });
 
-    // });
+    });
 
 });
 


### PR DESCRIPTION
In this PR, we:
* Add a component for the DiningCommonsTable
* Use that component on the DiningCommonsIndexPage

This allows the user to see a list of all DiningCommons.  It also provides a column with delete buttons to delete individual commons.

This is a front end to the backend routes that `GET` all records, and the backend route to `DELETE` one record by it's `code`.

# Screenshots

Before:


<img width="1308" alt="image" src="https://user-images.githubusercontent.com/1119017/168162632-2231e32e-2cef-4a0d-a4f8-b00a511c2620.png">

After:

<img width="1308" alt="image" src="https://user-images.githubusercontent.com/1119017/168166043-70d77da7-22d5-4a42-a10a-689350fdca8d.png">
