### PR TITLE
pc - add /diningCommons/create placeholder page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import TodosCreatePage from "main/pages/Todos/TodosCreatePage";
 import TodosEditPage from "main/pages/Todos/TodosEditPage";
 
 import DiningCommonsIndexPage from "main/pages/DiningCommons/DiningCommonsIndexPage";
+import DiningCommonsCreatePage from "main/pages/DiningCommons/DiningCommonsCreatePage";
 
 import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
@@ -44,6 +45,7 @@ function App() {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/diningCommons/list" element={<DiningCommonsIndexPage />} />
+              <Route exact path="/diningCommons/create" element={<DiningCommonsCreatePage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,8 +57,9 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
                {
                 hasRole(currentUser, "ROLE_USER") && (
-                  <NavDropdown title="UCSB Dining Commons" id="appnavbar-dining-commons-dropdown" data-testid="appnavbar-dining-commons-dropdown" >
-                    <NavDropdown.Item as={Link} to="/diningCommons/list" data-testid="appnavbar-dining-commons-list">List Dining Commons</NavDropdown.Item>
+                  <NavDropdown title="Dining Commons" id="appnavbar-dining-commons-dropdown" data-testid="appnavbar-dining-commons-dropdown" >
+                    <NavDropdown.Item as={Link} to="/diningCommons/list" data-testid="appnavbar-dining-commons-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/diningCommons/create" data-testid="appnavbar-dining-commons-create">Create</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/pages/DiningCommons/DiningCommonsCreatePage.js
+++ b/frontend/src/main/pages/DiningCommons/DiningCommonsCreatePage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function DiningCommonsCreatePage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Dining Commons</h1>
+        <p>
+          This is where the create page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/pages/DiningCommons/DiningCommonsCreatePage.test.js
+++ b/frontend/src/tests/pages/DiningCommons/DiningCommonsCreatePage.test.js
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import DiningCommonsCreatePage from "main/pages/DiningCommons/DiningCommonsCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("DiningCommonsCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DiningCommonsCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+


### PR DESCRIPTION
Closes #11 

In this PR, we add a placeholder page for the UCSB Dining Commons create page.

We also add it to the menu bar, and we make the menu a bit more compact.

# Screenshots

Before:

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/1119017/168907460-bc2ed5b8-6314-4c28-90af-f3c3183e5234.png">

After: 

The menu has two items and is more compact:

<img width="1217" alt="image" src="https://user-images.githubusercontent.com/1119017/168907642-6ff5c8c0-ec97-4f17-9640-c45df9323ea9.png">

The second item, Create, links to this page:

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/1119017/168907738-3bc0959d-b4d8-4a82-bad0-d287217dac1b.png">
