### PR TITLE
Add Form for creating and editing DiningCommons database entries.

### DIFF
--- a/frontend/src/main/components/DiningCommons/DiningCommonsForm.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsForm.js
@@ -16,15 +16,6 @@ function DiningCommonsForm({ initialCommons, submitAction, buttonLabel = "Create
 
     const navigate = useNavigate();
 
-
-    // "name": "Carrillo",
-    // "code": "carrillo",
-    // "hasSackMeal": false,
-    // "hasTakeOutMeal": false,
-    // "hasDiningCam": true,
-    // "latitude": 34.409953,
-    // "longitude": -119.85277
-
     const minLat = -90.0;
     const maxLat = 90.0;
     const minLong = -180.0;
@@ -119,6 +110,8 @@ function DiningCommonsForm({ initialCommons, submitAction, buttonLabel = "Create
                     data-testid="DiningCommonsForm-latitude"
                     id="latitude"
                     type="number"
+                    step="0.000001"
+                    precision={6}   
                     isInvalid={Boolean(errors.latitude)}
                     {...register("latitude", { required: true, min: minLat, max: maxLat })}
                 />
@@ -136,6 +129,8 @@ function DiningCommonsForm({ initialCommons, submitAction, buttonLabel = "Create
                     data-testid="DiningCommonsForm-longitude"
                     id="longitude"
                     type="number"
+                    step="0.000001"
+                    precision={6} 
                     isInvalid={Boolean(errors.longitude)}
                     {...register("longitude", { required: true, min: -180.0, max: 180.0 })}
                 />

--- a/frontend/src/main/components/DiningCommons/DiningCommonsForm.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsForm.js
@@ -1,0 +1,168 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+function DiningCommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialCommons || {} }
+    );
+    // Stryker enable all
+
+    const navigate = useNavigate();
+
+
+    // "name": "Carrillo",
+    // "code": "carrillo",
+    // "hasSackMeal": false,
+    // "hasTakeOutMeal": false,
+    // "hasDiningCam": true,
+    // "latitude": 34.409953,
+    // "longitude": -119.85277
+
+    const minLat = -90.0;
+    const maxLat = 90.0;
+    const minLong = -180.0;
+    const maxLong = 180.0;
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialCommons && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="code">Code</Form.Label>
+                    <Form.Control
+                        data-testid="DiningCommonsForm-code"
+                        id="code"
+                        type="text"
+                        {...register("code")}
+                        value={initialCommons.code}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+
+            {!initialCommons && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="code">Code</Form.Label>
+                    <Form.Control
+                        data-testid="DiningCommonsForm-code"
+                        id="code"
+                        type="text"
+                        isInvalid={Boolean(errors.code)}
+                        {...register("code", {
+                            required: "Code is required."
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.code?.message}
+                    </Form.Control.Feedback>
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="name">Name</Form.Label>
+                <Form.Control
+                    data-testid="DiningCommonsForm-name"
+                    id="name"
+                    type="text"
+                    isInvalid={Boolean(errors.name)}
+                    {...register("name", {
+                        required: "Name is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.name?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="hasSackMeal">Has Sack Meal?</Form.Label>
+                <Form.Check
+                    data-testid="DiningCommonsForm-hasSackMeal"
+                    type="checkbox"
+                    id="hasSackMeal"
+                    {...register("hasSackMeal")}
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="hasTakeOutMeal">Has Takeout Meal?</Form.Label>
+                <Form.Check
+                    data-testid="DiningCommonsForm-hasTakeOutMeal"
+                    type="checkbox"
+                    id="hasTakeOutMeal"
+                    {...register("hasTakeOutMeal")}
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="hasDiningCam">Has Dining Cam?</Form.Label>
+                <Form.Check
+                    data-testid="DiningCommonsForm-hasDiningCam"
+                    type="checkbox"
+                    id="hasDiningCam"
+                    {...register("hasDiningCam")}
+                />
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="latitude">Latitude</Form.Label>
+                <Form.Control
+                    data-testid="DiningCommonsForm-latitude"
+                    id="latitude"
+                    type="number"
+                    isInvalid={Boolean(errors.latitude)}
+                    {...register("latitude", { required: true, min: minLat, max: maxLat })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.latitude && 'latitude is required. '}
+                    {errors.latitude &&
+                        (errors.latitude.type === 'min' || errors.latitude.type === 'max') && `latitude should be between ${minLat} and ${maxLat}`}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="longitude">Longitude</Form.Label>
+                <Form.Control
+                    data-testid="DiningCommonsForm-longitude"
+                    id="longitude"
+                    type="number"
+                    isInvalid={Boolean(errors.longitude)}
+                    {...register("longitude", { required: true, min: -180.0, max: 180.0 })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.longitude && 'longitude is required. '}
+                    {errors.longitude &&
+                        (errors.longitude.type === 'min' || errors.longitude.type === 'max') && `longitude should be between ${minLong} and ${maxLong}`}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Button
+                type="submit"
+                data-testid="DiningCommonsForm-submit"
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid="DiningCommonsForm-cancel"
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default DiningCommonsForm;

--- a/frontend/src/stories/components/DiningCommons/DiningCommonsForm.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommonsForm.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import DiningCommonsForm from "main/components/DiningCommons/DiningCommonsForm"
+import { diningCommonsFixtures } from 'fixtures/diningCommonsFixtures';
+
+export default {
+    title: 'components/DiningCommons/DiningCommonsForm',
+    component: DiningCommonsForm
+};
+
+
+const Template = (args) => {
+    return (
+        <DiningCommonsForm {...args} />
+    )
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+    buttonLabel: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};
+
+export const Show = Template.bind({});
+
+Show.args = {
+    initialCommons: diningCommonsFixtures.oneDiningCommons,
+    buttonLabel: "Update",
+    submitAction: () => { }
+};

--- a/frontend/src/stories/components/DiningCommons/DiningCommonsForm.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommonsForm.stories.js
@@ -19,7 +19,7 @@ export const Default = Template.bind({});
 
 Default.args = {
     buttonLabel: "Create",
-    submitAction: () => { console.log("Submit was clicked"); }
+    submitAction: (data) => { console.log('Create was clicked, parameter to submitAction=',data); }
 };
 
 export const Show = Template.bind({});
@@ -27,5 +27,5 @@ export const Show = Template.bind({});
 Show.args = {
     initialCommons: diningCommonsFixtures.oneDiningCommons,
     buttonLabel: "Update",
-    submitAction: () => { }
+    submitAction: (data) => { console.log('Update was clicked, parameter to submitAction=',data); }
 };

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsForm.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsForm.test.js
@@ -1,0 +1,104 @@
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import DiningCommonsForm from "main/components/DiningCommons/DiningCommonsForm";
+import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("DiningCommonsForm tests", () => {
+
+    test("renders correctly ", async () => {
+
+        const { getByText } = render(
+            <Router  >
+                <DiningCommonsForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByText(/Name/)).toBeInTheDocument());
+        await waitFor(() => expect(getByText(/Create/)).toBeInTheDocument());
+    });
+
+
+    test("renders correctly when passing in a Commons ", async () => {
+
+        const { getByText, getByTestId } = render(
+            <Router  >
+                <DiningCommonsForm initialCommons={diningCommonsFixtures.oneDiningCommons}  buttonLabel={"Update"} />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId(/DiningCommonsForm-code/)).toBeInTheDocument());
+        expect(getByText(/Code/)).toBeInTheDocument();
+        await waitFor( () => expect(getByTestId(/DiningCommonsForm-code/)).toHaveValue("carrillo") );
+    });
+
+
+    test("Correct Error messsages when latitude and longitude exceed the max", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <DiningCommonsForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("DiningCommonsForm-code")).toBeInTheDocument());
+
+        const latitudeField = getByTestId("DiningCommonsForm-latitude");
+        const longitudeField = getByTestId("DiningCommonsForm-longitude");
+        const submitButton = getByTestId("DiningCommonsForm-submit");
+
+        fireEvent.change(latitudeField, { target: { value: '9999' } });
+        fireEvent.change(longitudeField, { target: { value: '8888' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/latitude should be between -90 and 90/)).toBeInTheDocument());
+        expect(getByText(/longitude should be between -180 and 180/)).toBeInTheDocument();
+        expect(getByText(/Code is required/)).toBeInTheDocument();
+    });
+
+
+    test("Correct Error messsages when latitude and longitude are below the min", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <DiningCommonsForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("DiningCommonsForm-code")).toBeInTheDocument());
+   
+        const latitudeField = getByTestId("DiningCommonsForm-latitude");
+        const longitudeField = getByTestId("DiningCommonsForm-longitude");
+        const submitButton = getByTestId("DiningCommonsForm-submit");
+
+        fireEvent.change(latitudeField, { target: { value: '-9999' } });
+        fireEvent.change(longitudeField, { target: { value: '-8888' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/latitude should be between -90 and 90/)).toBeInTheDocument());
+        expect(getByText(/longitude should be between -180 and 180/)).toBeInTheDocument();
+        expect(getByText(/Code is required/)).toBeInTheDocument();
+    });
+
+    test("Test that navigate(-1) is called when Cancel is clicked", async () => {
+
+        const { getByTestId } = render(
+            <Router  >
+                <DiningCommonsForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("DiningCommonsForm-cancel")).toBeInTheDocument());
+        const cancelButton = getByTestId("DiningCommonsForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});
+
+


### PR DESCRIPTION
# Overview

In this PR, we add a component for the DiningCommonsForm.   This component will be used in a later story on both the DiningCommonsCreatePage (this exists only as a placeholder for now), and the DiningCommonsEditPage (not yet created.)

This will eventually be used to allow the user to enter new records for DiningCommons and to edit those records.

# Issues Addressed

Closes #10 

# Link to Storybook

https://ucsb-cs156-s22.github.io/STARTER-team03-docs-qa/storybook-qa/pc-issue-10-diningCommonsForm/?path=/docs/components-diningcommons-diningcommonsform--default

Note that this PR only affects the storybook; we added a component to the storybook, but that component is not yet used in the frontend code.  That will be part of the next pull request.



# Test Plan (for interactive testing)

For now, this can only be tested via storybook, so see the link above.

Try different valid and invalid values, and you'll see the error messages.


