### PR TITLE
Pc issue 9: Allow user to create Dining Commons through front end page

### DIFF
--- a/frontend/src/main/pages/DiningCommons/DiningCommonsCreatePage.js
+++ b/frontend/src/main/pages/DiningCommons/DiningCommonsCreatePage.js
@@ -1,13 +1,53 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import DiningCommonsForm from "main/components/DiningCommons/DiningCommonsForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function DiningCommonsCreatePage() {
+export default function DiningCommonssCreatePage() {
+
+  const objectToAxiosParams = (commons) => ({
+    url: "/api/ucsbdiningcommons/post",
+    method: "POST",
+    params: {
+      code: commons.code,
+      name: commons.name,
+      hasSackMeal: commons.hasSackMeal,
+      hasTakeOutMeal: commons.hasTakeOutMeal,
+      hasDiningCam: commons.hasDiningCam,
+      latitude: commons.latitude,
+      longitude: commons.longitude,
+    }
+  });
+
+  const onSuccess = (commons) => {
+    toast(`New Dining Commons Created - code: ${commons.code} name: ${commons.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsbdiningcommons/all"]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/diningCommons/list" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Dining Commons</h1>
-        <p>
-          This is where the create page will go
-        </p>
+        <h1>Create New Dining Commons</h1>
+
+        <DiningCommonsForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/DiningCommons/DiningCommonsCreatePage.js
+++ b/frontend/src/main/pages/DiningCommons/DiningCommonsCreatePage.js
@@ -4,7 +4,7 @@ import { Navigate } from 'react-router-dom'
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function DiningCommonssCreatePage() {
+export default function DiningCommonsCreatePage() {
 
   const objectToAxiosParams = (commons) => ({
     url: "/api/ucsbdiningcommons/post",

--- a/frontend/src/tests/pages/DiningCommons/DiningCommonsCreatePage.test.js
+++ b/frontend/src/tests/pages/DiningCommons/DiningCommonsCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import DiningCommonsCreatePage from "main/pages/DiningCommons/DiningCommonsCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -9,14 +9,40 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+
 describe("DiningCommonsCreatePage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
     test("renders without crashing", () => {
+        const queryClient = new QueryClient();
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -25,6 +51,68 @@ describe("DiningCommonsCreatePage tests", () => {
             </QueryClientProvider>
         );
     });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+
+        const commons = {
+            "code": "ortega",
+            "name": "Ortega",
+            "hasSackMeal": true,
+            "hasTakeOutMeal": true,
+            "hasDiningCam": true,
+            "latitude": 30.0,
+            "longitude": -119.0
+          };
+        
+    
+        axiosMock.onPost("/api/ucsbdiningcommons/post").reply( 202, commons );
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DiningCommonsCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(getByTestId("DiningCommonsForm-code")).toBeInTheDocument();
+        });
+
+        const codeField = getByTestId("DiningCommonsForm-code");
+        const nameField = getByTestId("DiningCommonsForm-name");
+        const latitudeField = getByTestId("DiningCommonsForm-latitude");
+        const longitudeField = getByTestId("DiningCommonsForm-longitude");
+
+        const submitButton = getByTestId("DiningCommonsForm-submit");
+
+        fireEvent.change(codeField, { target: { value: 'ortega' } });
+        fireEvent.change(nameField, { target: { value: 'Ortega' } });
+        fireEvent.change(latitudeField, { target: { value: '30.0' } });
+        fireEvent.change(longitudeField, { target: { value: '-119.0' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            "code": "ortega",
+            "name": "Ortega",
+            "hasSackMeal": false,
+            "hasTakeOutMeal": false,
+            "hasDiningCam": false,
+            "latitude": '30.0',
+            "longitude": '-119.0'
+        });
+
+        expect(mockToast).toBeCalledWith("New Dining Commons Created - code: ortega name: Ortega");
+        expect(mockNavigate).toBeCalledWith({ "to": "/diningCommons/list" });
+    });
+
 
 });
 


### PR DESCRIPTION
# Overview

In this PR we add a page for creating Dining Commons entries in the database.

# Issues Addressed

Closes #9 

# User Story

* As a user
* I can create a Dining Commons entry
* So that the database has a record for each dining commons that exists.

# Details


Before: There is only a placeholder for the Dining Commons create page:

<img width="621" alt="image" src="https://user-images.githubusercontent.com/1119017/169178354-1dfdc64a-7796-43f9-803e-f0c36bf08e3e.png">

After: Note that there is a form for creating new Dining Commons:

<img width="1367" alt="image" src="https://user-images.githubusercontent.com/1119017/169178157-2039c688-7570-495c-9125-f99a6622354b.png">


# Animation of Creating new records

![create-new-dining-commons](https://user-images.githubusercontent.com/1119017/169178604-ff26cfee-0f56-44c5-b64e-485ae84f87ad.gif)

# Test Plan (for interactive testing)

* Go under Dining Commons menu
* Select Create
* Try entering some valid and invalid values
* Eventually try both the Create and Cancel buttons, and make sure they both work.

