### PR TITLE
Pc issue 8: Add Edit Page where Dining Commons can be edited

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,8 @@ import TodosEditPage from "main/pages/Todos/TodosEditPage";
 
 import DiningCommonsIndexPage from "main/pages/DiningCommons/DiningCommonsIndexPage";
 import DiningCommonsCreatePage from "main/pages/DiningCommons/DiningCommonsCreatePage";
+import DiningCommonsEditPage from "main/pages/DiningCommons/DiningCommonsEditPage";
+
 
 import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
@@ -45,7 +47,14 @@ function App() {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/diningCommons/list" element={<DiningCommonsIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
               <Route exact path="/diningCommons/create" element={<DiningCommonsCreatePage />} />
+              <Route exact path="/diningCommons/edit/:code" element={<DiningCommonsEditPage />} />
             </>
           )
         }
@@ -59,8 +68,8 @@ function App() {
         {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
-              <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
               <Route exact path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
+              <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
             </>
           )
         }

--- a/frontend/src/main/pages/DiningCommons/DiningCommonsEditPage.js
+++ b/frontend/src/main/pages/DiningCommons/DiningCommonsEditPage.js
@@ -1,0 +1,73 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import DiningCommonsForm from "main/components/DiningCommons/DiningCommonsForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function DiningCommonsEditPage() {
+  let { code } = useParams();
+
+  const { data: commons, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/ucsbdiningcommons?code=${code}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/ucsbdiningcommons`,
+        params: {
+          code
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (commons) => ({
+    url: "/api/ucsbdiningcommons",
+    method: "PUT",
+    params: {
+      code: commons.code,
+    },
+    data: {
+      name: commons.name,
+      hasSackMeal: commons.hasSackMeal,
+      hasTakeOutMeal: commons.hasTakeOutMeal,
+      hasDiningCam: commons.hasDiningCam,
+      latitude: commons.latitude,
+      longitude: commons.longitude,
+    }
+  });
+
+  const onSuccess = (commons) => {
+    toast(`DiningCommons Updated - code: ${commons.code} name: ${commons.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/ucsbdiningcommons?code=${code}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/diningCommons/list" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit Dining Commons</h1>
+        {commons &&
+          <DiningCommonsForm initialCommons={commons} submitAction={onSubmit} buttonLabel="Update" />
+        }
+      </div>
+    </BasicLayout>
+  )
+}
+

--- a/frontend/src/tests/pages/DiningCommons/DiningCommonsEditPage.test.js
+++ b/frontend/src/tests/pages/DiningCommons/DiningCommonsEditPage.test.js
@@ -1,0 +1,154 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import DiningCommonsEditPage from "main/pages/DiningCommons/DiningCommonsEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import _mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            code: "ortega"
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("DiningCommonsEditPage tests", () => {
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ucsbdiningcommons", { params: { code: "ortega" } }).reply(200, {  
+                name: "Ortega",
+                code: "ortega",
+                hasSackMeal: true,
+                hasTakeOutMeal: true,
+                hasDiningCam: true,
+                latitude: 34.410987,
+                longitude: -119.84709
+            });
+            axiosMock.onPut('/api/ucsbdiningcommons').reply(200, {
+                name: "Ortega Dining Commons",
+                code: "ortega",
+                hasSackMeal: true,
+                hasTakeOutMeal: true,
+                hasDiningCam: true,
+                latitude: 34.410123,
+                longitude: -119.847123
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <DiningCommonsEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <DiningCommonsEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await waitFor(() => expect(getByTestId("DiningCommonsForm-code")).toBeInTheDocument());
+
+            const codeField = getByTestId("DiningCommonsForm-code");
+            const nameField = getByTestId("DiningCommonsForm-name");
+            const latitudeField = getByTestId("DiningCommonsForm-latitude");
+            const longitudeField = getByTestId("DiningCommonsForm-longitude");
+
+            expect(codeField).toHaveValue("ortega");
+            expect(nameField).toHaveValue("Ortega");
+            expect(latitudeField).toHaveValue(34.410987);
+            expect(longitudeField).toHaveValue(-119.84709);
+        });
+
+        test("Changes when you click Update", async () => {
+
+            const { getByTestId, getByText } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <DiningCommonsEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await waitFor(() => expect(getByTestId("DiningCommonsForm-code")).toBeInTheDocument());
+
+            const codeField = getByTestId("DiningCommonsForm-code");
+            const nameField = getByTestId("DiningCommonsForm-name");
+            const latitudeField = getByTestId("DiningCommonsForm-latitude");
+            const longitudeField = getByTestId("DiningCommonsForm-longitude");
+
+            expect(codeField).toHaveValue("ortega");
+            expect(nameField).toHaveValue("Ortega");
+            expect(latitudeField).toHaveValue(34.410987);
+            expect(longitudeField).toHaveValue(-119.84709);
+           
+            const submitButton = getByText("Update");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(nameField, { target: { value: 'Ortega Dining Commons' } })
+            fireEvent.change(latitudeField, { target: { value: 34.410123 } })
+            fireEvent.change(longitudeField, { target: { value: -119.847123  } })
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled);
+            expect(mockToast).toBeCalledWith("DiningCommons Updated - code: ortega name: Ortega Dining Commons");
+            expect(mockNavigate).toBeCalledWith({ "to": "/diningCommons/list" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ code:"ortega" });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                name: "Ortega Dining Commons",
+                hasSackMeal: true,
+                hasTakeOutMeal: true,
+                hasDiningCam: true,
+                latitude: "34.410123",
+                longitude: "-119.847123"
+            })); // posted object
+
+        });
+
+       
+    });
+});
+
+


### PR DESCRIPTION
# Overview

In this PR, we add the edit page for DiningCommons.

For now, you have to go to this page manually; there is no button for it yet.  We'll do that in the next PR.

So to test, you put in a url such as: <http://localhost:8080/diningCommons/edit/ortega>

You'll see a page like this one, where you can edit the `ortega` dining commons:

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/1119017/169373283-69352d3a-5d74-4a04-94c8-7b274b893faa.png">


# Issues Addressed

closes #8 

# Test Plan (for interactive testing)

1. Go to the index page and make sure you have a DiningCommons record
2. Go to this url, where you have the `code` of a dining commons record in place of `ortega`
3. Try editing the record
4. When you click `Cancel`, it should not update
5. When you click `Update`, it should update and return you to the index page (i.e. the list of commons)

