### PR TITLE
Pc issue 7:  Add edit buttons to dining commons index page

### DIFF
--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -1,9 +1,8 @@
 import OurTable, { ButtonColumn} from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 import {  onDeleteSuccess } from "main/utils/UCSBDateUtils"
-// import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
-
 
 export function cellToAxiosParamsDelete(cell) {
     return {
@@ -17,11 +16,11 @@ export function cellToAxiosParamsDelete(cell) {
 
 export default function DiningCommonsTable({ diningCommons, currentUser }) {
 
-    // const navigate = useNavigate();
+    const navigate = useNavigate();
 
-    // const editCallback = (cell) => {
-    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
-    // }
+    const editCallback = (cell) => {
+        navigate(`/diningCommons/edit/${cell.row.values.code}`)
+    }
 
     // Stryker disable all : hard to test for query caching
     const deleteMutation = useBackendMutation(
@@ -73,7 +72,7 @@ export default function DiningCommonsTable({ diningCommons, currentUser }) {
 
     const columnsIfAdmin = [
         ...columns,
-        // ButtonColumn("Edit", "primary", editCallback, testid),
+        ButtonColumn("Edit", "primary", editCallback, testid),
         ButtonColumn("Delete", "danger", deleteCallback, testid)
     ];
 

--- a/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
 import { diningCommonsFixtures } from 'fixtures/diningCommonsFixtures';
-import { apiCurrentUserFixtures, currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 export default {
     title: 'components/DiningCommons/DiningCommonsTable',

--- a/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
 import { diningCommonsFixtures } from 'fixtures/diningCommonsFixtures';
+import { apiCurrentUserFixtures, currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 export default {
     title: 'components/DiningCommons/DiningCommonsTable',
@@ -26,4 +27,10 @@ ThreeDates.args = {
     diningCommons: diningCommonsFixtures.threeCommons
 };
 
+export const ThreeDatesAsAdmin = Template.bind({});
+
+ThreeDatesAsAdmin.args = {
+    diningCommons: diningCommonsFixtures.threeCommons,
+    currentUser: currentUserFixtures.adminUser
+};
 

--- a/frontend/src/tests/pages/DiningCommons/DiningCommonsIndexPage.test.js
+++ b/frontend/src/tests/pages/DiningCommons/DiningCommonsIndexPage.test.js
@@ -22,6 +22,13 @@ jest.mock('react-toastify', () => {
     };
 });
 
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
 describe("UCSBDatesIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
@@ -167,6 +174,35 @@ describe("UCSBDatesIndexPage tests", () => {
         await waitFor(() => { expect(mockToast).toBeCalledWith("DiningCommons with id de-la-guerra was deleted") });
 
     });
+
+    test("test what happens when you click edit as an admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DiningCommonsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toBeInTheDocument(); });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); 
+
+
+        const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+        expect(editButton).toBeInTheDocument();
+       
+        fireEvent.click(editButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/diningCommons/edit/de-la-guerra'));
+
+    });
+
 
 });
 


### PR DESCRIPTION
# Overview

In this PR, we add the edit button to the DiningCommonsIndexPage.

# Issues Addressed

Closes #7 

# Link to Storybook

We added a story that shows what the `DiningCommonsTable` component looks like with 
three rows, and when the user is an admin:

[Three Dates As Admin](https://ucsb-cs156-s22.github.io/STARTER-team03-docs-qa/storybook-qa/pc-issue-7-AddEditButtonsToDiningCommonsIndexPage/?path=/story/components-diningcommons-diningcommonstable--three-dates-as-admin)

# Details

Before screenshot

<img width="986" alt="image" src="https://user-images.githubusercontent.com/1119017/169382218-69b23420-da70-4f9d-911e-0f4905c14135.png">

After screenshot

<img width="993" alt="image" src="https://user-images.githubusercontent.com/1119017/169382291-ec741826-3e95-40af-a599-5faf99d2afc8.png">

Animation:

![dining-commons-edit-button](https://user-images.githubusercontent.com/1119017/169382451-33343e3f-1bb1-4809-9fa8-c4c3a35c7cad.gif)


# Test Plan (for interactive testing)

1. Go to the Dining Commons menu, select List
2. If there aren't are Dining Commons, go to Create and make one
3. Find the Edit button next to a Dining Commons and click it
4. You should go to the edit page for that Dining Commons


